### PR TITLE
Add actions support and improve testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,46 +3,98 @@
 [![License](https://img.shields.io/github/license/Ayowel/renpy-setup-action)](https://github.com/Ayowel/renpy-setup-action/blob/master/LICENSE)
 [![Latest version](https://img.shields.io/github/v/tag/Ayowel/renpy-setup-action)](https://www.github.com/Ayowel/renpy-setup-action/releases/latest)
 
-This action installs Ren'Py with DLCs and modules.
-Ren'Py may then be used from the command-line to lint or build your project.
-
-## Inputs
-
-The step configuration looks like this:
-
-```yml
-- uses: Ayowel/renpy-setup-action@v0.1.0
-  with:
-    # The base Ren'Py version to download.
-    version: 8.0.3
-    # Any Ren'Py DLC that should be added to the installation.
-    # If listing more than one dlc, separate them with commas.
-    dlc: steam
-    # The directory where Ren'Py will be installed.
-    # The directory may not exist when the action runs.
-    install_dir: renpy/
-    # Path to the live2d release that should be installed.
-    # This option is not supported yet.
-    live2d: https://cubism.live2d.com/sdk-native/bin/CubismSdkForNative-4-r.5.1.zip
-```
-
-## Output
-
-| Output name | Description |
-| :---: | :--- |
-| __`install_dir`__ | Path to Ren'Py's install directory |
-| __`renpy_path`__ | Path to the Ren'Py executable |
-| __`python_path`__ | Path to the python executable embedded in Ren'Py |
+This action installs Ren'Py with DLCs and modules and allows you to perform simple actions on your code with it.
 
 ## Usage
 
-To minimize the action runtime, we recommend to cache the generated directory. When doing so, output values can't be used as the action may not run:
+### Distribute release packages
+
+Easily build release packages for multiple platforms.
+
+```yml
+# .github/workflows/distribute.yml
+name: Distribute code
+on:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: project
+      - uses: Ayowel/renpy-setup-action@v1.0.0
+        with:
+          action: distribute
+          version: 8.0.3
+          game: project
+          packages: linux, win
+          out_dir: target
+```
+
+### Lint project
+
+Ensure that your code does not have structural issues without even running the game.
+
+```yml
+# .github/workflows/lint.yml
+name: Distribute code
+on:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: project
+      - uses: Ayowel/renpy-setup-action@v1.0.0
+        with:
+          action: lint
+          version: 8.0.3
+          game: project
+```
+
+### Install
+
+Or simply install Ren'Py to use commands of your choosing.
+
+```yml
+# .github/workflows/install.yml
+name: Install Ren'Py
+on:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: Ayowel/renpy-setup-action@v1.0.0
+        with:
+          action: install
+          version: 8.0.3
+          install_dir: renpy
+          dlc: steam
+```
+
+## Optimization and tips
+
+### Use the cache
+
+You should use the action with caching for best performance. Add the `install_dir` input and cache the corresponding directory with `@actions/cache`.
 
 ```yml
 # .github/workflows/lint.yml
 name: Lint code
+
 on:
   push:
+
 env:
   RENPY_VERSION: 8.0.3
 
@@ -55,32 +107,33 @@ jobs:
         with:
           path: project
       - uses: actions/cache@v3
-        id: cache-renpy
         with:
           path: renpy
-          key: ${{ runner.os }}-renpy
-      - uses: Ayowel/renpy-setup-action@v0.1.0
-        if: steps.cache-renpy.outputs.cache-hit != 'true'
+          key: ${{ runner.os }}-renpy-${{ env.RENPY_VERSION }}
+      - uses: Ayowel/renpy-setup-action@v1.0.0
         with:
+          action: lint
           version: ${{ env.RENPY_VERSION }}
-          dlc: steam
           install_dir: renpy
-      - name: Run Ren'Py linter
-        run: |
-          renpy/renpy.sh project lint
+          game: project
 ```
 
-You may also use the action without caching, however the action will take between 30 seconds and 1 minute more:
+### Use implicit installs
+
+When using a non-install action, if Ren'Py is not installed yet, it will be installed first. When doing so, any install-related input provided will be honored.
+
+### Provide distribution files paths
+
+The packages list may contain a path for a generated package. When doing so, the  value `out_dir` will be ignored for the files with a path.
+Note that a file extension will automatically be added, so the raw name provided can't be relied upon without gobing the actual file.
+
+In the following example, the linux release will be created in `linux-target/` with a custom name while the windows and mac releases
 
 ```yml
-# .github/workflows/lint.yml
-name: Lint code
-
+# .github/workflows/distribute.yml
+name: Distribute code
 on:
-  push:
-
-env:
-  RENPY_VERSION: 8.0.3
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -88,13 +141,61 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: Ayowel/renpy-setup-action@v0.1.0
-        if: steps.cache-renpy.outputs.cache-hit != 'true'
-        id: renpy
         with:
-          version: ${{ env.RENPY_VERSION }}
-          dlc: steam
-      - name: Run Ren'Py linter
-        run: |
-          ${{ steps.renpy.outputs.renpy_path }} . lint
+          path: project
+      - uses: Ayowel/renpy-setup-action@v1.0.0
+        with:
+          action: distribute
+          version: 8.0.3
+          game: project
+          packages: |
+            linux linux-target/distrib_linux
+            win, mac
+          out_dir: target
 ```
+
+## Inputs
+
+This action supports the following inputs:
+
+```yml
+- uses: Ayowel/renpy-setup-action@v1.0.0
+  with:
+    # What the action should do.
+    # Must be one of 'install', 'distribute', and 'lint'
+    action: install
+    # Directory where Ren'Py is/will be installed.
+    # The directory may not exist if the action is install.
+    # If the directory does not exist and the action is not
+    # 'install', Ren'Py will be installed before running
+    # the action.
+    install_dir: ~/.renpy_exec
+    # Directory of the Ren'Py game
+    game: .
+
+    ### INSTALL INPUTS ###
+    # Comma/space-separated list of Ren'Py DLCs to install
+    dlc: steam
+    # Path to a live2d release to install.
+    # This option is not supported yet.
+    live2d: https://cubism.live2d.com/sdk-native/bin/CubismSdkForNative-4-r.5.1.zip
+    # Whether Ren'Py's directory should be added to the PATH
+    update_path: false
+    # Downloaded Ren'Py version when installing
+    version: 8.0.3
+
+    ### DISTRIBUTE INPUTS ###
+    # Comma/newline-separated list of packages that should
+    # be built
+    packages: all
+    # Directory where generated packages should be saved
+    out_dir: ""
+```
+
+## Output
+
+| Output name | Description |
+| :---: | :--- |
+| __`install_dir`__ | Path to Ren'Py's install directory |
+| __`renpy_path`__ | Path to the Ren'Py executable |
+| __`python_path`__ | Path to the Python executable embedded in Ren'Py |

--- a/__tests__/executor.test.ts
+++ b/__tests__/executor.test.ts
@@ -1,0 +1,134 @@
+import fs from 'fs';
+import path from 'path';
+
+import { createTmpDir, initContext } from './helpers/test_helpers.test';
+import { RenpyExecutor } from '../src/executor';
+import { RenpyInstaller } from '../src/installer';
+import { RenpyDistributeOptions } from '../src/models';
+
+let readonly_tmp_dir: string;
+let renpy8_dir: string;
+beforeAll(async () => {
+  initContext();
+  readonly_tmp_dir = createTmpDir();
+  renpy8_dir = path.join(readonly_tmp_dir, 'renpy');
+  const installer = new RenpyInstaller(renpy8_dir, '8.0.3');
+  await installer.installCore();
+}, 5 * 60 * 1000);
+
+afterAll(async () => {
+  fs.rmSync(readonly_tmp_dir, { recursive: true });
+});
+
+let tmp_dirs: string[] = [];
+afterEach(async () => {
+  for (const tmpdir of tmp_dirs) {
+    fs.rmSync(tmpdir, { recursive: true });
+  }
+  tmp_dirs = [];
+
+  jest.resetAllMocks();
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+});
+
+describe('RenpyExecutor introspection methods run as expected', () => {
+  test('RenpyExecutor.getDirectory returns the proper path', () => {
+    const executor = new RenpyExecutor(renpy8_dir);
+    expect(executor.getDirectory()).toBe(renpy8_dir);
+  });
+
+  test('RenpyExecutor.getPythonPath resolves to the right path', () => {
+    const executor = new RenpyExecutor(renpy8_dir);
+    const pypath = executor.getPythonPath();
+    expect(fs.existsSync(pypath)).toBe(true);
+    expect(fs.statSync(pypath).mode & 100).toBeTruthy();
+  });
+
+  test('RenpyExecutor.getPythonPath fails if python is not found', async () => {
+    const fake_dir = createTmpDir();
+    tmp_dirs.push(fake_dir);
+    const executor = new RenpyExecutor(fake_dir);
+    expect(() => executor.getPythonPath()).toThrow();
+  });
+
+  test('RenpyExecutor.getRenpyPath resolves to the right path', () => {
+    const executor = new RenpyExecutor(renpy8_dir);
+    const renpy_path = executor.getRenpyPath();
+    expect(fs.existsSync(renpy_path)).toBe(true);
+    expect(fs.statSync(renpy_path).mode & 100).toBeTruthy();
+  });
+
+  test("RenpyExecutor.getRenpyPath fails if Ren'Py is not found", async () => {
+    const fake_dir = createTmpDir();
+    tmp_dirs.push(fake_dir);
+    const executor = new RenpyExecutor(fake_dir);
+    expect(() => executor.getRenpyPath()).toThrow();
+  });
+});
+
+describe('RenpyExecutor.lint runs as expected', () => {
+  it.each([
+    [true, 'label start:\n    "Hello"'],
+    [false, 'label start:\n    jump thislabeldoesnotexist']
+  ])('Should the linter call succeed ? %s', async (should_resolve, script_content) => {
+    const game_dir = createTmpDir();
+    tmp_dirs.push(game_dir);
+    fs.mkdirSync(path.join(game_dir, 'game'));
+    fs.writeFileSync(path.join(game_dir, 'game', 'scripts.rpy'), script_content);
+
+    const executor = new RenpyExecutor(renpy8_dir);
+    const test = expect(executor.lint(game_dir, {}));
+    if (should_resolve) {
+      await test.resolves.not.toThrow();
+    } else {
+      await test.rejects.toThrow();
+    }
+  });
+});
+
+describe('RenpyExecutor.distribute runs as expected', () => {
+  let game_dir: string;
+  beforeEach(async () => {
+    game_dir = createTmpDir();
+    tmp_dirs.push(game_dir);
+    fs.mkdirSync(path.join(game_dir, 'game'));
+    const script_content = ['define build.name = "testgame"', 'label start:', '    "Hello"'].join(
+      '\n'
+    );
+    fs.writeFileSync(path.join(game_dir, 'game', 'scripts.rpy'), script_content);
+  });
+
+  test(
+    'Build several packages',
+    async () => {
+      const target_dir = path.join(game_dir, 'target');
+      const executor = new RenpyExecutor(renpy8_dir);
+      const opts: RenpyDistributeOptions = {
+        packages: ['win', 'mac'],
+        target_dir
+      };
+      await executor.distribute(game_dir, opts);
+      expect(fs.readdirSync(target_dir).length).toBe(opts.packages.length);
+    },
+    5 * 60 * 1000
+  );
+
+  test(
+    'Build a package with target name',
+    async () => {
+      const target_dir = path.join(game_dir, 'target');
+      const short_name = 'testproject';
+      const executor = new RenpyExecutor(renpy8_dir);
+      const opts: RenpyDistributeOptions = {
+        packages: [['linux', path.join(target_dir, short_name)]],
+        target_dir: ''
+      };
+      await executor.distribute(game_dir, opts);
+      const dir_content = fs.readdirSync(target_dir);
+      expect(dir_content.length).toBe(1);
+      expect(path.basename(dir_content[0]).startsWith(short_name)).toBeTruthy();
+    },
+    5 * 60 * 1000
+  );
+});

--- a/__tests__/helpers/test_helpers.test.ts
+++ b/__tests__/helpers/test_helpers.test.ts
@@ -1,0 +1,60 @@
+import fs from 'fs';
+import https from 'https';
+import path from 'path';
+import { env } from 'process';
+
+import * as tc from '@actions/tool-cache';
+
+// CI complains if a non-test .ts file is outside /src
+// Jest complains if a .test.ts does not contain a test
+test('noop', () => {
+  expect(true).toBe(true);
+});
+
+export function initContext() {
+  env.RUNNER_TEMP = getCache();
+  const spyTcDownloadTool = jest.spyOn(tc, 'downloadTool');
+  spyTcDownloadTool.mockImplementation(toolCacheDownloadToolMock);
+}
+
+export function getCache() {
+  return fs.mkdirSync('test_cache', { recursive: true }) || 'test_cache';
+}
+
+export function createTmpDir(): string {
+  return fs.mkdtempSync('jest-setup-renpy-');
+}
+
+export async function toolCacheDownloadToolMock(
+  url: string,
+  dest: string | undefined
+): Promise<string> {
+  const filename = url.split('/').pop() as string;
+  const cache_path = path.join(getCache(), filename);
+  if (fs.existsSync(cache_path)) {
+    if (dest) {
+      fs.symlinkSync(dest, cache_path);
+    } else {
+      dest = cache_path;
+    }
+    return fs.realpathSync(dest);
+  }
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, res => {
+      if (res.statusCode && res.statusCode >= 400) {
+        reject('Received error code');
+      }
+      const filePath = fs.createWriteStream(cache_path);
+      res.pipe(filePath);
+      filePath.on('finish', async () => {
+        filePath.close();
+        if (dest) {
+          fs.symlinkSync(dest, cache_path);
+        } else {
+          dest = cache_path;
+        }
+        resolve(fs.realpathSync(dest));
+      });
+    });
+  });
+}

--- a/__tests__/io.test.ts
+++ b/__tests__/io.test.ts
@@ -1,0 +1,90 @@
+import * as io from '../src/io';
+import * as core from '@actions/core';
+import { RenpyOutputs } from '../src/models';
+
+jest.mock('@actions/core');
+
+afterEach(() => {
+  jest.resetAllMocks();
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+});
+
+test('io.test calls core.setFailed', () => {
+  const error_message = 'Test error message';
+  io.fail(error_message);
+  expect(core.setFailed).toHaveBeenCalledWith(error_message);
+});
+
+test('io.getLogger provides a logger that writes to @actions/core', () => {
+  const log_message = 'Test info message';
+  io.getLogger().info(log_message);
+  expect(core.info).toHaveBeenCalledWith(log_message);
+});
+
+test('io.writeOutputs uses @actions/core', () => {
+  const outputs: RenpyOutputs = {
+    install_dir: 'renpy/path',
+    renpy_path: 'renpy/path/renpy.sh',
+    python_path: 'renpy/path/lib/python'
+  };
+  io.writeOutputs(outputs);
+  expect(core.setOutput).toHaveBeenCalledWith('install_dir', outputs.install_dir);
+  expect(core.setOutput).toHaveBeenCalledWith('renpy_path', outputs.renpy_path);
+  expect(core.setOutput).toHaveBeenCalledWith('python_path', outputs.python_path);
+});
+
+describe('io.parseInputs properly handle input values', () => {
+  let input: { [k: string]: string } = {};
+  beforeEach(() => {
+    input = {
+      action: 'install' // default value
+    };
+    const spyCoreGetInput = jest.spyOn(core, 'getInput');
+    spyCoreGetInput.mockImplementation(key => input[key] || '');
+  });
+
+  test('Unknown actions throw an error', () => {
+    input['action'] = 'unsupportedactionname';
+    expect(io.parseInputs).toThrow();
+  });
+
+  it.each([
+    ['', []],
+    ['  steam  ', ['steam']],
+    ['steam, renios', ['steam', 'renios']],
+    [' steam renios ', ['steam', 'renios']]
+  ])('Dlc install list is properly parsed: "%s"', (input_dlc, expected) => {
+    input['dlc'] = input_dlc;
+    const opts = io.parseInputs();
+    expect(opts.action).toBe('install');
+    expect(opts.install_opts.dlc_list).toEqual(expected);
+  });
+
+  it.each([
+    ['', ['all']], // Build all by default
+    ['all', ['all']],
+    [' win, mac ', ['win', 'mac']],
+    ['win\nmac', ['win', 'mac']],
+    ['win path/to/win\nmac', [['win', 'path/to/win'], 'mac']],
+    [' win, mac   path/to/mac  \n linux ', ['win', ['mac', 'path/to/mac'], 'linux']]
+  ])('Package distribution list is properly parsed: "%s"', (input_pkg, expected) => {
+    input['action'] = 'distribute';
+    input['packages'] = input_pkg;
+    const opts = io.parseInputs();
+    expect(opts.action).toBe('distribute');
+    expect(opts.distribute_opts?.packages).toEqual(expected);
+  });
+
+  test('Mapping the "all" package to a file path throws an error', () => {
+    input['action'] = 'distribute';
+    input['packages'] = 'all path/to/all';
+    expect(io.parseInputs).toThrow();
+  });
+
+  test('Lint action is properly detected', () => {
+    input['action'] = 'lint';
+    const opts = io.parseInputs();
+    expect(opts.action).toBe('lint');
+  });
+});

--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,52 @@
+import os from 'os';
+import * as utils from '../src/utils';
+
+describe('utils.stringToBool properly parses strings', () => {
+  it.each([
+    ['true', true, true],
+    ['true', false, true],
+    ['false', true, false],
+    ['false', false, false],
+    ['', true, true],
+    ['', false, false]
+  ])("String '%s' with default %s returns %s", (str, def, expected) => {
+    expect(utils.stringToBool(str, def)).toBe(expected);
+  });
+
+  test('Providing a non-boolean string throws an error', () => {
+    expect(() => utils.stringToBool('NotABool', false)).toThrow();
+  });
+});
+
+describe('utils.pickOsValue changes its return value depending on the platform', () => {
+  let current_platform: NodeJS.Platform = os.platform();
+  beforeEach(() => {
+    current_platform = os.platform();
+    const spyOsPlatform = jest.spyOn(os, 'platform');
+    spyOsPlatform.mockImplementation(() => current_platform);
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it.each([
+    ['win32', 0],
+    ['linux', 1],
+    ['darwin', 2]
+  ] as [NodeJS.Platform, number][])(
+    'On %s platforms, the parameter %s is returned',
+    (pf, index) => {
+      current_platform = pf;
+      const params: [string, string, string] = ['param1', 'param2', 'param3'];
+      expect(utils.pickOsValue(...params)).toBe(params[index]);
+    }
+  );
+
+  test('Throws on unsupported platforms', () => {
+    current_platform = 'aix';
+    expect(() => utils.pickOsValue(1, 2, 3)).toThrow();
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -1,21 +1,40 @@
-name: "Setup Ren'Py Environment"
-description: "Setup Ren'Py"
+name: "Ren'Py setup"
+description: "Install, build, and test Ren'Py games"
 branding:
   color: blue
   icon: aperture
 inputs:
-  dlc:
-    description: "Comma-separated list of dlcs to install"
-    required: false
+  action:
+    description: "What should be done with the action"
+    default: install
   install_dir:
     description: "Where Ren'Py should be installed"
+    required: false
+  # Install action
+  dlc:
+    description: "List of dlcs to install"
     required: false
   live2d:
     description: "Live2D url of the file to install (Live2D won't be installed if this is not set)"
     required: false
+  update_path:
+    description: "Whether the install directory should be added to the PATH"
+    required: false
   version:
     description: "Ren'Py version to install"
-    required: true
+    required: false
+  # All non-install actions
+  game:
+    description: "Path to the game's directory"
+    required: false
+  # Distribute action
+  packages:
+    description: "List of release packages to build"
+    required: false
+  out_dir:
+    description: ""
+    required: false
+  # Lint action has no inputs
 outputs:
   install_dir:
     description: "The directory where Ren'Py is installed"

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,0 +1,129 @@
+import * as cp from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getLogger } from './io';
+import { RenpyDistributeOptions, RenpyLintOptions } from './models';
+import { pickOsValue } from './utils';
+
+const logger = getLogger();
+
+enum RenpyExecutableName {
+  Linux = 'renpy.sh',
+  Mac = 'renpy.dmg',
+  Windows = 'renpy.exe'
+}
+
+export class RenpyExecutor {
+  private directory: string;
+
+  constructor(directory: string) {
+    this.directory = directory;
+  }
+
+  public async distribute(game: string, opts: RenpyDistributeOptions) {
+    const generic_pkg = opts.packages.filter(s => typeof s == 'string') as string[];
+    const targeted_pkg = opts.packages.filter(s => typeof s != 'string') as [string, string][];
+
+    if (generic_pkg.length > 0) {
+      const args = ['', 'distribute', game];
+      generic_pkg.forEach(p => args.push('--package', p as string));
+      if (opts.target_dir) {
+        args.push('--destination', opts.target_dir);
+      }
+      logger.info(`Building distributions for ${generic_pkg}`);
+      await this.execute(args);
+      logger.info('Done');
+    }
+    for (const pkg_info of targeted_pkg) {
+      const args = ['', 'distribute', game];
+      args.push('--package', pkg_info[0]);
+      args.push('--packagedest', pkg_info[1]);
+      const target_dir = path.dirname(pkg_info[1]);
+      if (target_dir) {
+        fs.mkdirSync(target_dir, { recursive: true });
+      }
+      logger.info(`Building distribution for ${pkg_info[0]}`);
+      await this.execute(args);
+      logger.info('Done');
+    }
+  }
+
+  public async lint(game: string, opts: RenpyLintOptions) {
+    const [stdout, stderr] = await this.execute([game, 'lint', '--error-code']);
+    logger.info(stdout);
+    logger.warning(stderr);
+  }
+
+  protected async execute(args: string[]): Promise<[string, string]> {
+    return new Promise((resolve, reject) => {
+      let stdout = '';
+      let stderr = '';
+      logger.debug(`Execute command "${this.getRenpyPath()}" ${args}`);
+      const child = cp.spawn(this.getRenpyPath(), args);
+      const log = (logger: (m: string) => void, message: string | string[]) => {
+        const messages = typeof message == 'string' ? message.split('\n') : message;
+        messages.forEach(line => {
+          logger(`${child.pid} ${line}`);
+        });
+      };
+      child.stdout.on('data', data => {
+        stdout += data;
+        log(logger.debug, '' + data);
+      });
+      child.stderr.on('data', data => {
+        stderr += data;
+        log(logger.debug, '' + data);
+      });
+      child.on('close', status => {
+        if (status == 0) {
+          resolve([stdout, stderr]);
+        } else {
+          log(
+            logger.error,
+            [
+              `Child process ${child.pid} failed with error code ${status}`,
+              `${stdout}`,
+              `${stderr}`
+            ].join('\n\n')
+          );
+          reject(Error(`${child.pid} Failed to execute command "${this.getRenpyPath()}" ${args}`));
+        }
+      });
+    });
+  }
+
+  public getDirectory(): string {
+    return this.directory;
+  }
+
+  public getPythonPath(): string {
+    const os = pickOsValue('windows', 'linux', 'mac');
+    const ext = pickOsValue('.exe', '', '');
+    const python_paths = [
+      `lib/py3-${os}-x86_64/python${ext}`,
+      `lib/py2-${os}-x86_64/python${ext}`,
+      `lib/${os}-x86_64/python${ext}`
+    ];
+    for (const p of python_paths) {
+      const candidate_path = path.join(this.directory, p);
+      if (fs.existsSync(candidate_path)) {
+        return candidate_path;
+      }
+    }
+    throw Error("Failed to find Python executable in Ren'Py directory.");
+  }
+
+  public getRenpyPath(): string {
+    const exec_name = pickOsValue(
+      RenpyExecutableName.Windows,
+      RenpyExecutableName.Linux,
+      RenpyExecutableName.Mac
+    );
+    const renpy_path = path.join(this.directory, exec_name);
+    if (fs.existsSync(renpy_path)) {
+      return renpy_path;
+    } else {
+      throw Error("Failed to find Ren'Py executable in Ren'Py directory.");
+    }
+  }
+}

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,28 +1,71 @@
 import os from 'os';
 import path from 'path';
 import * as core from '@actions/core';
-import { RenpyInstallerOptions, RenpyOutputs } from './models';
+import { RenpyInputs, RenpyOutputs } from './models';
+import { stringToBool } from './utils';
 
-export function parseInputs(): RenpyInstallerOptions {
+export function parseInputs(): RenpyInputs {
+  const logger = getLogger();
   const version = core.getInput('version');
   let install_dir = core.getInput('install_dir');
 
-  const opts: RenpyInstallerOptions = {
-    version: core.getInput('version'),
-    dlc_list: core
-      .getInput('dlc')
-      .split(',')
-      .map(v => v.trim())
-      .filter(s => !!s),
-    live2d_url: core.getInput('live2d'),
-    install_dir: install_dir ? install_dir : path.join(os.homedir(), '.renpy_exec', version)
+  const opts: RenpyInputs = {
+    action: core.getInput('action'),
+    game_dir: core.getInput('game') || '.',
+    install_dir: install_dir || path.join(os.homedir(), '.renpy_exec'),
+    install_opts: {
+      version: core.getInput('version') || '8.0.3',
+      dlc_list: core
+        .getInput('dlc')
+        .split(/,|\s+/)
+        .map(v => v.trim())
+        .filter(s => !!s),
+      live2d_url: core.getInput('live2d'),
+      update_path: stringToBool(core.getInput('update_path'), false)
+    }
   };
+  logger.debug(`Mapped dlc input "${core.getInput('dlc')}" to ${opts.install_opts.dlc_list}`);
+  switch (opts.action) {
+    case 'install':
+      break;
+    case 'distribute':
+      opts.distribute_opts = {
+        packages: (core.getInput('packages') || 'all')
+          .split(/,|\n/)
+          .map(v => v.trim())
+          .filter(s => !!s)
+          .map(s => {
+            const splitted = s.split(/\s+/);
+            if (splitted.length == 1) {
+              return s;
+            } else {
+              const pkg_name = splitted[0];
+              if (pkg_name == 'all') {
+                throw Error(
+                  `Specifying a package file name for the generic 'all' package is not supported (in '${s}').`
+                );
+              }
+              const path = s.substring(pkg_name.length).trim();
+              return [pkg_name, path];
+            }
+          }),
+        target_dir: core.getInput('out_dir')
+      };
+      break;
+    case 'lint':
+      opts.lint_opts = {};
+      break;
+    default:
+      throw Error(`Invalid action: ${opts.action}`);
+  }
   return opts;
 }
 
 export function writeOutputs(out: RenpyOutputs) {
   for (const k in out) {
-    core.setOutput(k, out);
+    if ((out as any)[k] !== undefined) {
+      core.setOutput(k, (out as any)[k]);
+    }
   }
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,9 +1,25 @@
+export interface RenpyInputs {
+  action: string;
+  install_dir: string;
+  game_dir: string;
+  install_opts: RenpyInstallerOptions;
+  distribute_opts?: RenpyDistributeOptions;
+  lint_opts?: RenpyLintOptions;
+}
+
 export interface RenpyInstallerOptions {
   version: string;
   dlc_list: string[];
   live2d_url: string;
-  install_dir: string;
+  update_path: boolean;
 }
+
+export interface RenpyDistributeOptions {
+  packages: (string | [string, string])[];
+  target_dir: string;
+}
+
+export interface RenpyLintOptions {}
 
 export interface RenpyOutputs {
   install_dir: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,26 @@
+import os from 'os';
+import path from 'path';
+import tc from '@actions/tool-cache';
+
+export function stringToBool(value: string, default_value: boolean): boolean {
+  if (!value) {
+    return default_value;
+  }
+  if (!['true', 'false'].includes(value.toLowerCase())) {
+    throw Error(`Received an arbitrary string where a boolean was expected: ${value}`);
+  }
+  return value.toLowerCase() == 'true';
+}
+
+export function pickOsValue<T, U, V>(windows: T, linux: U, mac: V): T | U | V {
+  switch (os.platform()) {
+    case 'linux':
+      return linux;
+    case 'win32':
+      return windows;
+    case 'darwin':
+      return mac;
+    default:
+      throw Error(`Unsupported platform: ${os.platform}`);
+  }
+}


### PR DESCRIPTION
* Add RenpyExecutor class to provide support for 'distribute' and 'lint' actions
* Move install logic to RenpyInstaller.install
* Add utils.ts to provide small helper functions
* Centralize helper functions for tests in test_utils.ts
* Add many tests