### PR TITLE
Update update/current.json when installing a Ren'Py DLC

### DIFF
--- a/__tests__/controller/executor.test.ts
+++ b/__tests__/controller/executor.test.ts
@@ -71,20 +71,24 @@ describe('RenpyExecutor.lint runs as expected', () => {
   it.each([
     [true, 'label start:\n    "Hello"'],
     [false, 'label start:\n    jump thislabeldoesnotexist']
-  ])('Should the linter call succeed ? %s', async (should_resolve, script_content) => {
-    const game_dir = createTmpDir();
-    tmp_dirs.push(game_dir);
-    fs.mkdirSync(path.join(game_dir, 'game'));
-    fs.writeFileSync(path.join(game_dir, 'game', 'scripts.rpy'), script_content);
+  ])(
+    'Should the linter call succeed ? %s',
+    async (should_resolve, script_content) => {
+      const game_dir = createTmpDir();
+      tmp_dirs.push(game_dir);
+      fs.mkdirSync(path.join(game_dir, 'game'));
+      fs.writeFileSync(path.join(game_dir, 'game', 'scripts.rpy'), script_content);
 
-    const executor = new RenpyExecutor(renpy8_dir);
-    const test = expect(executor.lint(game_dir, {}));
-    if (should_resolve) {
-      await test.resolves.not.toThrow();
-    } else {
-      await test.rejects.toThrow();
-    }
-  });
+      const executor = new RenpyExecutor(renpy8_dir);
+      const test = expect(executor.lint(game_dir, {}));
+      if (should_resolve) {
+        await test.resolves.not.toThrow();
+      } else {
+        await test.rejects.toThrow();
+      }
+    },
+    15 * 1000
+  );
 });
 
 describe('RenpyExecutor.distribute runs as expected', () => {

--- a/__tests__/controller/installer.test.ts
+++ b/__tests__/controller/installer.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { getCache, createTmpDir, initContext } from '../helpers/test_helpers.test';
 import { RenpyInstaller } from '../../src/controller/installer';
 import { RenpyInstallerOptions } from '../../src/model/parameters';
+import { RenpyDlcUpdateCurrent } from '../../src/model/renpy';
 
 jest.mock('@actions/core');
 
@@ -78,6 +79,18 @@ describe('isDlcInstallWorking', () => {
       const location = renpy_dir;
       for (const filepath of expect_files) {
         expect(fs.existsSync(path.join(location, filepath))).toBeTruthy();
+      }
+      /* Ensure the update file was changed */
+      const current_json_file_path = path.join(renpy_dir, 'update', 'current.json');
+      const current_json_content = JSON.parse(
+        fs.readFileSync(current_json_file_path, 'utf-8')
+      ) as RenpyDlcUpdateCurrent;
+      const current_keys: string[] = [];
+      for (const key in current_json_content) {
+        current_keys.push(key);
+      }
+      for (const dlc of dlcs) {
+        expect(current_keys).toContain(dlc);
       }
     },
     3 * 60 * 1000

--- a/src/controller/installer.ts
+++ b/src/controller/installer.ts
@@ -127,7 +127,7 @@ export class RenpyInstaller {
       },
       file_list
     );
-    // TODO: extract update/current.json content and call updateCurrentJson
+    await this.updateCurrentJson(dlc_content);
   }
 
   private buildDlcFilelist(update: RenpyDlcUpdateInfo): string[] {
@@ -141,12 +141,12 @@ export class RenpyInstaller {
     return filelist;
   }
 
-  private updateCurrentJson(update: RenpyDlcUpdateCurrent) {
+  private async updateCurrentJson(update: RenpyDlcUpdateCurrent) {
     const update_file = path.join(this.install_dir, 'update', 'current.json');
     const content = JSON.parse(fs.readFileSync(update_file, 'utf-8')) as RenpyDlcUpdateCurrent;
     for (const k in update) {
       content[k] = update[k];
     }
-    fs.writeFileSync(update_file, JSON.stringify(content));
+    fs.writeFileSync(update_file, JSON.stringify(content, null, 2));
   }
 }


### PR DESCRIPTION
The current implementation updates `update/current.json` while keeping the indentation of the release file. This is not Ren'Py's default behavior when adding DLCs as it minimizes the generated JSON file in the process