### PR TITLE
Return absolute file paths in action outputs

### DIFF
--- a/src/setup-renpy.ts
+++ b/src/setup-renpy.ts
@@ -30,9 +30,9 @@ async function main() {
     }
 
     const outputs: RenpyOutputs = {
-      install_dir: executor.getDirectory(),
-      python_path: executor.getPythonPath(),
-      renpy_path: executor.getRenpyPath()
+      install_dir: fs.realpathSync(executor.getDirectory()),
+      python_path: fs.realpathSync(executor.getPythonPath()),
+      renpy_path: fs.realpathSync(executor.getRenpyPath())
     };
 
     switch (opts.action) {


### PR DESCRIPTION
Relative file paths cause issues whe the action's workflow uses the output after changing directory.