### PR TITLE
Fix typo in translation inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ After installing Ren'Py, use the `translate` action to update the game's transla
     action: translate
     install_dir: renpy
     game: project
-    language: french english
+    languages: french english
 ```
 
 ### Get layout information

--- a/__tests__/setup-renpy.test.ts
+++ b/__tests__/setup-renpy.test.ts
@@ -77,6 +77,7 @@ describe('main properly handles input parameters', () => {
     input['action'] = action;
     input['install_dir'] = tmpdir;
     input['build_type'] = 'apk';
+    input['languages'] = 'None';
     await expect(main()).resolves.not.toThrow();
     expect(core.setFailed).not.toHaveBeenCalled();
     expect((RenpyExecutor.prototype as { [id: string]: any })[method]).toHaveBeenCalledTimes(1);

--- a/action.yml
+++ b/action.yml
@@ -66,10 +66,9 @@ inputs:
     description: "The arguments that should be passed to Ren'Py as a string"
     required: false
   # translate action
-  language:
+  languages:
     description: "The languages for which translations should be updated"
     required: false
-    default: None
   # Lint action has no inputs
 outputs:
   install_dir:


### PR DESCRIPTION
Fix a typo that made the translation action unusable in practice and add automatic detection of supported languages.